### PR TITLE
bugfix - purchaseEquipment undefined memberName

### DIFF
--- a/main/gang/auto-gang.js
+++ b/main/gang/auto-gang.js
@@ -78,7 +78,7 @@ export async function main(ns) {
         if (ns.gang.recruitMember(name)) {
           ns.print(`INFO: Recruited new gang member '${name}`)
           ns.gang.setMemberTask(name, cycleTasks[0])
-          purchaseEquipment()
+          purchaseEquipment(name)
         }
       })
     }


### PR DESCRIPTION
This fixes problem when recruiting a new member.
It tries to purchase equipment for the member, but the code never passes any name to the function so the game throws this error: `gang.purchaseEquipment: memberName expected to be a string. Is undefined.`